### PR TITLE
Fix documentation errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## xkcd-imgs [![Build Status](https://travis-ci.org/hemanth/node-xkcd-img.svg)](https://travis-ci.org/hemanth/node-xkcd-img)
+# xkcd-imgs [![Build Status](https://travis-ci.org/hemanth/node-xkcd-img.svg)](https://travis-ci.org/hemanth/node-xkcd-img)
 
 > Get random xkcd comics.
 
@@ -19,7 +19,9 @@ xkcd.img(function(err, res){
 });
 
 // Would log something like:
-{ url: 'http://imgs.xkcd.com/comics/mystery_news.png',
-  img_title: 'If you find and stop the video, but you\'ve--against all odds--gotten curious about the trade summit, just leave the tab opened. It will mysteriously start playing again 30 minutes later!' 
+{
+  url: 'http://imgs.xkcd.com/comics/mystery_news.png',
+  title: 'If you find and stop the video, but you\'ve--against all odds--gotten curious about the trade summit, just leave the tab opened. It will mysteriously start playing again 30 minutes later!'
 }
 ```
+


### PR DESCRIPTION
Fix documentation errors:
1. In the example. The module returns an object with property `title` and not `img_title`.
2. Main heading should be a `<h1></h1>`
